### PR TITLE
Guarentee package lsof is installed

### DIFF
--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -23,6 +23,7 @@
 
 include_recipe "java"
 package 'unzip'
+package 'lsof' # Required to launch the neo4j service
 
 #
 # User accounts


### PR DESCRIPTION
CentOS minimal ISO doesn't ship with the lsof utility by default, which is necessary to launch the Neo4J server.
