### PR TITLE
Comments out the node_keys_indexable setting if node_indexes are disable...

### DIFF
--- a/templates/default/neo4j.properties.erb
+++ b/templates/default/neo4j.properties.erb
@@ -22,7 +22,7 @@ keep_logical_logs=true
 node_auto_indexing=<%= node.neo4j.server.node_auto_indexing.enabled %>
 
 # The node property keys to be auto-indexed, if enabled
-node_keys_indexable=<%= node.neo4j.server.node_auto_indexing.keys_indexable %>
+<%= node.neo4j.server.node_auto_indexing.enabled ? '' : '#' %>node_keys_indexable=<%= node.neo4j.server.node_auto_indexing.keys_indexable %>
 
 # Enable auto-indexing for relationships, default is false
 #relationship_auto_indexing=true


### PR DESCRIPTION
...d

In the previous pull request that added attributes for node_indexing, the default list of node_keys_indexable was set to the empty string. However, with Neo4j 2.0.0-M03, I am getting the following error when not using node auto indexing: 

SEVERE: Bad value '' for setting 'node_keys_indexable': Must be a comma-separated list of keys to be indexed 

This patch will comment out the node_keys_indexable property when node_auto_indexing is not enabled.
