### PR TITLE
Extract top level directory from tar better?

### DIFF
--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -71,7 +71,7 @@ bash "extract #{tmp}, move it to #{node.neo4j.server.installation_dir}" do
   code <<-EOS
     rm -rf #{node.neo4j.server.installation_dir}
     tar xfz #{tmp}
-    mv --force `tar -tf #{tmp} | head -n 1` #{node.neo4j.server.installation_dir}
+    mv --force `tar -tf #{tmp} | head -n 1 | cut -d/ -f 1` #{node.neo4j.server.installation_dir}
   EOS
 
   creates "#{node.neo4j.server.installation_dir}/bin/neo4j"


### PR DESCRIPTION
Not sure what's going on here, but I need this change to use this cookbook. Suspect there may be a difference in the output of `tar tf`? 

Certainly in the version I have in a `precise64.box` the first entry is a .jar file, which then causes a failure later on with 'not a directory'. The change in this PR fixes it for me, so I'm submitting it for discussion.

```
vagrant@precise64:~$ uname -a
Linux precise64 3.2.0-23-generic #36-Ubuntu SMP Tue Apr 10 20:39:51 UTC 2012 x86_64 x86_64 x86_64 GNU/Linux
vagrant@precise64:~$ tar --version
tar (GNU tar) 1.26

vagrant@precise64:/tmp$ sudo tar tfz neo4j-community-1.9.2.tar.gz | head -n 1
neo4j-community-1.9.2/lib/neo4j-kernel-1.9.2.jar

vagrant@precise64:/tmp$ sudo tar tfz neo4j-community-1.9.2.tar.gz | head -n 1 | cut -d/ -f 1
neo4j-community-1.9.2
```
