### PR TITLE
A more complete HTTPS configuration

### DIFF
--- a/attributes/tarball.rb
+++ b/attributes/tarball.rb
@@ -25,7 +25,11 @@ default[:neo4j][:server][:http][:host]       = '0.0.0.0'
 
 default[:neo4j][:server][:http][:enabled]    = true
 default[:neo4j][:server][:http][:port]       = 7474
-default[:neo4j][:server][:https][:enabled]   = true
+
+default[:neo4j][:server][:https][:enabled]        = true
+default[:neo4j][:server][:https][:port]           = 7473
+default[:neo4j][:server][:https][:cert_location]  = 'conf/ssl/snakeoil.cert'
+default[:neo4j][:server][:https][:key_location]   = 'conf/ssl/snakeoil.key'
 
 default[:neo4j][:server][:plugins][:spatial][:enabled]  = true
 default[:neo4j][:server][:plugins][:spatial][:version]  = '0.9-SNAPSHOT'

--- a/templates/default/neo4j-server.properties.erb
+++ b/templates/default/neo4j-server.properties.erb
@@ -35,13 +35,13 @@ org.neo4j.server.webserver.port=<%= node.neo4j.server.http.port %>
 org.neo4j.server.webserver.https.enabled=<%= node.neo4j.server.https.enabled %>
 
 # https port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.https.port=7473
+org.neo4j.server.webserver.https.port=<%= node.neo4j.server.https.port %>
 
 # Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=conf/ssl/snakeoil.cert
+org.neo4j.server.webserver.https.cert.location=<%= node.neo4j.server.https.cert_location %>
 
 # Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=conf/ssl/snakeoil.key
+org.neo4j.server.webserver.https.key.location=<%= node.neo4j.server.https.key_location %>
 
 # Internally generated keystore (don't try to put your own
 # keystore there, it will get deleted when the server starts)


### PR DESCRIPTION
Two key changes:
- HTTPS configuration options
- Ability to disable HTTP endpoint

Both are options that I make use of on my own Neo4j server and figured would be useful for others.
