### PR TITLE
Update README to reflect the correct :host parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ via `node[:neo4j][:server][:version]` or `node.neo4j.server.version` and so on.
 * `:lock_path`: .lock file location (default: /var/run/neo4j-server.lock)
 * `:pid_path`: .pid file location (default: /var/run/neo4j-server.pid)
 * `[:jvm][:xmx]`: maximum allowed JVM heap size, in MB (-Xmx JVM flag value) (default: 512)
-* `[:http][:host]`: what interface (or host) should HTTP transport listen on (default: 0.0.0.0)
+* `[:host]`: what interface (or host) should HTTP transport listen on (default: 0.0.0.0)
 * `[:http][:port]`: what port should HTTP transport listen on (default: 7474)
 * `[:https][:enabled]`: whether HTTPS transport is enabled (default: true)
 * `[:remote_shell][:port]`: remote_shell_port (default: 1337)


### PR DESCRIPTION
Commit 137936884e349e78e0958396b3d4c3b3444d242f changed [:server][:http][:host] to [:server][:host], so this just updates the README as well.
