### PR TITLE
Add defaults for all new options

### DIFF
--- a/attributes/tarball.rb
+++ b/attributes/tarball.rb
@@ -44,5 +44,9 @@ default[:neo4j][:server][:remote_shell][:port] = 1337
 default[:neo4j][:server][:ha][:enabled] = false
 default[:neo4j][:server][:ha][:server_id] = "1"
 default[:neo4j][:server][:ha][:initial_hosts] = nil
+default[:neo4j][:server][:ha][:server] = nil
+default[:neo4j][:server][:ha][:cluster_server] = nil
 default[:neo4j][:server][:ha][:pull_interval] = 10
+default[:neo4j][:server][:ha][:tx_push_factor] = nil
+default[:neo4j][:server][:ha][:tx_push_strategy] = nil
 


### PR DESCRIPTION
Sorry about that -- I forgot to add proper defaults for new options in #32 , which means all these conditionals in the template will break (the value just doesn't exist, so it throws a `TemplateError: Undefined method or attribute 'tx_push_factor' on 'node'`).

This commit fixes the issue by giving `nil` defaults to all new options.